### PR TITLE
Update owo-colors to 4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Removed
+
+## 0.7.1
+
+### Changed
+
+ - Updated `owo-colors` to 4.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ homepage = "https://github.com/romankoblov/prettydiff"
 rust-version = "1.70"
 
 [dependencies]
-owo-colors = { version = "3.5.0" }
+owo-colors = "4.0"
 pad = "0.1.6"
 prettytable-rs = { version = "0.10.0", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prettydiff"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Roman Koblov <penpen938@me.com>"]
 edition = "2018"
 description = "Side-by-side diff for two files"


### PR DESCRIPTION
I'm trying to update owo-colors in Clippy's deptree past the 3.x series so that when https://github.com/jam1garner/owo-colors/pull/131 lands people can pull in the fix.

# TODO (check if already done)
* [x] Add tests
* [x] Add CHANGELOG.md entry