### PR TITLE
Remove the csv feature from prettytable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+ - Reduced build bloat.
+
 ### Fixed
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.70"
 [dependencies]
 owo-colors = "4.0"
 pad = "0.1.6"
-prettytable-rs = { version = "0.10.0", optional = true }
+prettytable-rs = { version = "0.10.0", optional = true, default-features = false }
 
 [features]
 cli = ["prettytable-rs"]


### PR DESCRIPTION
To reduce build bloat, because prettydiff doesn't need it.


# TODO (check if already done)
* [ ] Add tests
* [x] Add CHANGELOG.md entry
